### PR TITLE
processMessages thread should now start on client connection.

### DIFF
--- a/src/starvationevasion/server/Server.java
+++ b/src/starvationevasion/server/Server.java
@@ -51,7 +51,7 @@ public class Server
 
   private void start()
   {
-    new Thread(this::processMessages);
+    new Thread(this::processMessages).start();
     waitForConnections();
   }
 


### PR DESCRIPTION
This is a necessary code fix in order to communicate events such as the Login with the server.
