### PR TITLE
In the scenario of a User choice region selected, the regionmap remai…

### DIFF
--- a/src/starvationevasion/server/Server.java
+++ b/src/starvationevasion/server/Server.java
@@ -247,7 +247,10 @@ public class Server
     if (Login.generateHashedPassword(client.getLoginNonce(),
         passwordFile.credentialMap.get(message.username)).equals(message.hashedPassword))
     {
-      client.setRegion(passwordFile.regionMap.get(message.username));
+      if (passwordFile.regionMap != null)
+      {
+        client.setRegion(passwordFile.regionMap.get(message.username));
+      }
       client.setUserName(message.username);
       client.send(new LoginResponse(client.getRegion() != null ?
           LoginResponse.ResponseType.ASSIGNED_REGION : LoginResponse.ResponseType.CHOOSE_REGION, client.getRegion()));


### PR DESCRIPTION
when logging in there needs to be a check on whether or not the regionMap is null before attempting to set the user's region.

@Phyxius You have been assigned this PR
