### PR TITLE
Merge castellanos70 f7645fd with ss013r 13b5e9b

### DIFF
--- a/src/starvationevasion/common/gamecards/Policy_FoodReliefCentralAsia.java
+++ b/src/starvationevasion/common/gamecards/Policy_FoodReliefCentralAsia.java
@@ -12,11 +12,11 @@ import starvationevasion.server.model.State;
  * Draft Affects: When drafting this policy, player
  * selects a food to send 5 thousand tons to Central Asia. <br><br>
  *
- * Votes Required: {@value #VOTES_REQUIRED} 1<br>
+ * Votes Required: Automatic<br><br>
  * Eligible Regions: All U.S.<br><br>
  *
  * Model Effects: Commodity food is distributed to relieve world hunger
- * in Central Asia.  Import penaly costs apply to the aid.<br><br>
+ * in Central Asia.  Import penalty costs apply to the aid.<br><br>
  *
  * Food purchased for relief inflates the global sell foodPrice of the food type by a
  * direct reduction of supply without effect on demand (since those to whom the
@@ -30,16 +30,8 @@ public class Policy_FoodReliefCentralAsia extends GameCard
   public static final String TEXT = 
 	"This region sends 5 thousand tons of target food to Central Asia";
   
-  public static final int VOTES_REQUIRED = 1;
-  
   public static final EnumSet<State> PLAY_STATES = //when the card can be used
       EnumSet.of(State.DRAFTING);
-  
-  /**
-   *  {@inheritDoc}
-   */
-  @Override
-  public int votesRequired() {return VOTES_REQUIRED;}
 
   /**
    *  {@inheritDoc}

--- a/src/starvationevasion/common/gamecards/Policy_FoodReliefMiddleAmerica.java
+++ b/src/starvationevasion/common/gamecards/Policy_FoodReliefMiddleAmerica.java
@@ -12,11 +12,11 @@ import starvationevasion.server.model.State;
  * Draft Affects: When drafting this policy, player
  * selects a food to send 5 thousand tons to Middle America. <br><br>
  *
- * Votes Required: {@value #VOTES_REQUIRED} 1<br>
+ * Votes Required: Automatic<br><br>
  * Eligible Regions: All U.S.<br><br>
  *
  * Model Effects: Commodity food is distributed to relieve world hunger
- * in Middle America.  Import penaly costs apply to the aid.<br><br>
+ * in Middle America.  Import penalty costs apply to the aid.<br><br>
  *
  * Food purchased for relief inflates the global sell foodPrice of the food type by a
  * direct reduction of supply without effect on demand (since those to whom the
@@ -29,17 +29,9 @@ public class Policy_FoodReliefMiddleAmerica extends GameCard
 
   public static final String TEXT = 
 	"This region sends 5 thousand tons of target food to Middle America";
-
-  public static final int VOTES_REQUIRED = 1;
   
   public static final EnumSet<State> PLAY_STATES = //when the card can be used
       EnumSet.of(State.DRAFTING);
-
-  /**
-   *  {@inheritDoc}
-   */
-  @Override
-  public int votesRequired() {return VOTES_REQUIRED;}
 
   /**
    *  {@inheritDoc}

--- a/src/starvationevasion/common/gamecards/Policy_FoodReliefOceania.java
+++ b/src/starvationevasion/common/gamecards/Policy_FoodReliefOceania.java
@@ -12,11 +12,11 @@ import starvationevasion.server.model.State;
  * Draft Affects: When drafting this policy, player
  * selects a food to send 5 thousand tons to Oceania. <br><br>
  *
- * Votes Required: {@value #VOTES_REQUIRED} 1<br>
+ * Votes Required: Automatic<br><br>
  * Eligible Regions: All U.S.<br><br>
  *
  * Model Effects: Commodity food is distributed to relieve world hunger
- * in Oceania.  Import penaly costs apply to the aid.<br><br>
+ * in Oceania.  Import penalty costs apply to the aid.<br><br>
  *
  * Food purchased for relief inflates the global sell foodPrice of the food type by a
  * direct reduction of supply without effect on demand (since those to whom the
@@ -30,16 +30,8 @@ public class Policy_FoodReliefOceania extends GameCard
   public static final String TEXT = 
 	"This region sends 5 thousand tons of target food to Oceania";
 
-  public static final int VOTES_REQUIRED = 1;
-  
   public static final EnumSet<State> PLAY_STATES = //when the card can be used
       EnumSet.of(State.DRAFTING);
-
-  /**
-   *  {@inheritDoc}
-   */
-  @Override
-  public int votesRequired() {return VOTES_REQUIRED;}
 
   /**
    *  {@inheritDoc}

--- a/src/starvationevasion/common/gamecards/Policy_FoodReliefSouthAsia.java
+++ b/src/starvationevasion/common/gamecards/Policy_FoodReliefSouthAsia.java
@@ -12,11 +12,11 @@ import starvationevasion.server.model.State;
  * Draft Affects: When drafting this policy, player
  * selects a food to send 5 thousand tons to South Asia. <br><br>
  *
- * Votes Required: {@value #VOTES_REQUIRED} 1<br>
+ * Votes Required: Automatic<br><br>
  * Eligible Regions: All U.S.<br><br>
  *
  * Model Effects: Commodity food is distributed to relieve world hunger
- * in South Asia.  Import penaly costs apply to the aid.<br><br>
+ * in South Asia.  Import penalty costs apply to the aid.<br><br>
  *
  * Food purchased for relief inflates the global sell foodPrice of the food type by a
  * direct reduction of supply without effect on demand (since those to whom the
@@ -30,16 +30,8 @@ public class Policy_FoodReliefSouthAsia extends GameCard
   public static final String TEXT = 
 	"This region sends 5 thousand tons of target food to South Asia";
 
-  public static final int VOTES_REQUIRED = 1;
-  
   public static final EnumSet<State> PLAY_STATES = //when the card can be used
       EnumSet.of(State.DRAFTING);
-
-  /**
-   *  {@inheritDoc}
-   */
-  @Override
-  public int votesRequired() {return VOTES_REQUIRED;}
 
   /**
    *  {@inheritDoc}

--- a/src/starvationevasion/common/gamecards/Policy_FoodReliefSubSaharan.java
+++ b/src/starvationevasion/common/gamecards/Policy_FoodReliefSubSaharan.java
@@ -12,11 +12,11 @@ import starvationevasion.server.model.State;
  * Draft Affects: When drafting this policy, player
  * selects a food to send 5 thousand tons to Central Asia. <br><br>
  *
- * Votes Required: {@value #VOTES_REQUIRED} 1<br>
+ * Votes Required: Automatic<br><br>
  * Eligible Regions: All U.S.<br><br>
  *
  * Model Effects: Commodity food is distributed to relieve world hunger
- * in Sub Saharan Africa.  Import penaly costs apply to the aid.<br><br>
+ * in Sub Saharan Africa.  Import penalty costs apply to the aid.<br><br>
  *
  * Food purchased for relief inflates the global sell foodPrice of the food type by a
  * direct reduction of supply without effect on demand (since those to whom the
@@ -30,16 +30,8 @@ public class Policy_FoodReliefSubSaharan extends GameCard
   public static final String TEXT = 
 	"This region sends 5 thousand tons of target food to Sub Saharan Africa";
 
-  public static final int VOTES_REQUIRED = 1;
-  
   public static final EnumSet<State> PLAY_STATES = //when the card can be used
       EnumSet.of(State.DRAFTING);
-
-  /**
-   *  {@inheritDoc}
-   */
-  @Override
-  public int votesRequired() {return VOTES_REQUIRED;}
 
   /**
    *  {@inheritDoc}

--- a/src/starvationevasion/server/handlers/CardHandler.java
+++ b/src/starvationevasion/server/handlers/CardHandler.java
@@ -102,7 +102,7 @@ public class CardHandler extends AbstractHandler
     {
       GameCard policyCard = (GameCard) request.getPayload().getData();
 
-      if (getClient().getUser().actionPointsRemaining >= 1 && getClient().getUser().drafts < 2)
+      if (getClient().getUser().actionPointsRemaining >= policyCard.actionPointCost(policyCard.getCardType()) && getClient().getUser().drafts < 2)
       {
 
         if (policyCard.getOwner().equals(getClient().getUser().getRegion()))


### PR DESCRIPTION
More changes to the policy cards, might fix issues mentioned by @javierchavez with his synthetic unit tests.

Stephen Sagartz's comment:
Changed some errors inside of FoodRelief Policy cards and removed the VOTES_REQUIRED field in them, as they should be automatic.

Also added a change in CardHandler that checks to see if the action points remaining when a player wants to draft a card is more than or equal to the action point cost of that card.
